### PR TITLE
Add Authentication REST Controller with JDK 21 Record for Token Refresh

### DIFF
--- a/src/main/java/com/example/authsystem/controller/AuthController.java
+++ b/src/main/java/com/example/authsystem/controller/AuthController.java
@@ -1,0 +1,70 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.AuthRequest;
+import com.example.authsystem.dto.AuthResponse;
+import com.example.authsystem.dto.LoginRequest;
+import com.example.authsystem.dto.SignUpRequest;
+import com.example.authsystem.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin(origins = "*")
+@Tag(name = "Authentication", description = "Authentication management APIs")
+public class AuthController {
+    
+    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
+    
+    private final AuthService authService;
+    
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+    
+    @PostMapping("/signup")
+    @Operation(summary = "Register a new user", description = "Create a new user account")
+    @ApiResponse(responseCode = "201", description = "User registered successfully")
+    @ApiResponse(responseCode = "409", description = "Email already exists")
+    public ResponseEntity<AuthResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        logger.info("Registration request received for email: {}", request.email());
+        
+        AuthResponse response = authService.authenticate(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+    @PostMapping("/login")
+    @Operation(summary = "Authenticate user", description = "Login with email and password")
+    @ApiResponse(responseCode = "200", description = "Login successful")
+    @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        logger.info("Login request received for email: {}", request.email());
+        
+        AuthResponse response = authService.authenticate(request);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PostMapping("/refresh")
+    @Operation(summary = "Refresh access token", description = "Get new access token using refresh token")
+    @ApiResponse(responseCode = "200", description = "Token refreshed successfully")
+    @ApiResponse(responseCode = "401", description = "Invalid refresh token")
+    public ResponseEntity<AuthResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
+        logger.info("Token refresh request received");
+        
+        AuthResponse response = authService.refreshToken(request.refreshToken());
+        return ResponseEntity.ok(response);
+    }
+    
+    // JDK 21 Record for refresh token request
+    public record RefreshTokenRequest(
+            @jakarta.validation.constraints.NotBlank(message = "Refresh token is required")
+            String refreshToken
+    ) {}
+}


### PR DESCRIPTION
This PR introduces the AuthController class to handle authentication-related endpoints:

- POST /signup – user registration

- POST /login – user authentication

- POST /refresh – refresh token endpoint using a JDK 21 record